### PR TITLE
Add reminder no diacritics

### DIFF
--- a/app/views/citationterms/entities/index.html.erb
+++ b/app/views/citationterms/entities/index.html.erb
@@ -1,5 +1,6 @@
 <% if can? :read, Entity %>
   <h2>Jesuits index</h2>
+  <p> Reminder: Do not use diacritics when filtering </p>
 
   <div class="button-group">
     <%= link_to 'Add New Jesuit record', new_citationterms_entity_path, class: 'btn btn-primary' %>

--- a/app/views/citationterms/journals/index.html.erb
+++ b/app/views/citationterms/journals/index.html.erb
@@ -1,5 +1,6 @@
 <% if can? :read, Journal %>
   <h2>Journal Title index</h2>
+  <p> Reminder: Do not use diacritics when filtering </p>
 
   <div class="button-group">
     <%= link_to 'Add New Journal Title record', new_citationterms_journal_path, class: 'btn btn-primary' %>

--- a/app/views/citationterms/locations/index.html.erb
+++ b/app/views/citationterms/locations/index.html.erb
@@ -1,5 +1,6 @@
 <% if can? :read, Location %>
   <h2>Location terms index</h2>
+<p> Reminder: Do not use diacritics when filtering </p>
 
   <div class="button-group">
     <%= link_to 'Add New Location term', new_citationterms_location_path, class: 'btn btn-primary' %>

--- a/app/views/citationterms/locations/index.html.erb
+++ b/app/views/citationterms/locations/index.html.erb
@@ -1,6 +1,6 @@
 <% if can? :read, Location %>
   <h2>Location terms index</h2>
-<p> Reminder: Do not use diacritics when filtering </p>
+  <p> Reminder: Do not use diacritics when filtering </p>
 
   <div class="button-group">
     <%= link_to 'Add New Location term', new_citationterms_location_path, class: 'btn btn-primary' %>

--- a/app/views/citationterms/people/index.html.erb
+++ b/app/views/citationterms/people/index.html.erb
@@ -1,5 +1,6 @@
 <% if can? :read, Person %>
   <h2>People terms index</h2>
+  <p> Reminder: Do not use diacritics when filtering </p>
 
   <div class="button-group">
     <%= link_to 'Add New Person term', new_citationterms_person_path, class: 'btn btn-primary' %>

--- a/app/views/citationterms/periods/index.html.erb
+++ b/app/views/citationterms/periods/index.html.erb
@@ -1,5 +1,6 @@
 <% if can? :read, Period %>
   <h2>Century terms index</h2>
+  <p> Reminder: Do not use diacritics when filtering </p>
 
   <div class="button-group">
     <%= link_to 'Add New Century term', new_citationterms_period_path, class: 'btn btn-primary' %>

--- a/app/views/citationterms/subjects/index.html.erb
+++ b/app/views/citationterms/subjects/index.html.erb
@@ -1,6 +1,6 @@
 <% if can? :read, Subject %>
   <h2>Subject terms Index</h2>
-<p> Reminder: Do not use diacritics when filtering </p>
+  <p> Reminder: Do not use diacritics when filtering </p>
 
   <div class="button-group">
     <%= link_to 'Add New Subject term', new_citationterms_subject_path, class: 'btn btn-primary' %>

--- a/app/views/citationterms/subjects/index.html.erb
+++ b/app/views/citationterms/subjects/index.html.erb
@@ -1,5 +1,6 @@
 <% if can? :read, Subject %>
   <h2>Subject terms Index</h2>
+<p> Reminder: Do not use diacritics when filtering </p>
 
   <div class="button-group">
     <%= link_to 'Add New Subject term', new_citationterms_subject_path, class: 'btn btn-primary' %>


### PR DESCRIPTION
They asked for a short reminder on the term list filtering pages not to use diacritics when filtering. I added it to the html for each term page (except languages because there were no diacritics). They seem fine with the search set up the way it is now in terms of diacritics.