### PR TITLE
Dissertation type fix and ISBN hint added

### DIFF
--- a/app/models/bibliography.rb
+++ b/app/models/bibliography.rb
@@ -172,7 +172,7 @@ class Bibliography < ApplicationRecord
     BOOK_AUTHOR_EDITOR_HINT = 'Either Author or Editor is required'
     DOI_HINT = 'Only enter the numeric ID for each DOI (e.g. 10.1177/239693930903300206)'
     YEAR_PUBLISHED_HINT = 'Only records for items since 2000 will be published. Publication with a range of years should take the form 2002-08'
-    ISBN_HINT = 'Only enter the number ID for each ISBN with no dashes (e.g. 1234567890123)'
+    ISBN_HINT = 'Only enter the numeric ID for each ISBN with no dashes (e.g. 1234567890123)'
     
     # Define static lists/values here
     COMMENT_TYPES = ['Note', 'Research note', 'Note to editor'].freeze

--- a/app/models/bibliography.rb
+++ b/app/models/bibliography.rb
@@ -172,7 +172,8 @@ class Bibliography < ApplicationRecord
     BOOK_AUTHOR_EDITOR_HINT = 'Either Author or Editor is required'
     DOI_HINT = 'Only enter the numeric ID for each DOI (e.g. 10.1177/239693930903300206)'
     YEAR_PUBLISHED_HINT = 'Only records for items since 2000 will be published. Publication with a range of years should take the form 2002-08'
-
+    ISBN_HINT = 'Only enter the number ID for each ISBN with no dashes (e.g. 1234567890123)'
+    
     # Define static lists/values here
     COMMENT_TYPES = ['Note', 'Research note', 'Note to editor'].freeze
     STATUS_LIST = ['submitted', 'reviewed', 'pending', 'published'].freeze

--- a/app/models/concerns/citations_generator.rb
+++ b/app/models/concerns/citations_generator.rb
@@ -97,7 +97,7 @@ module CitationsGenerator
                 # A Ph.D. thesis.
                 # Required fields: author, title, school, year
                 # Optional fields: type, address, month, note, key
-                if self.dissertation_thesis_type.present? and self.dissertation_thesis_type.downcase.include? "phd"
+                if self.dissertation_thesis_type.present? and self.dissertation_thesis_type.downcase.include? "ph"
                     @b.type = :phdthesis
                 else
                     @b.type = :mastersthesis

--- a/app/views/bibliographies/fields/_isbn.erb
+++ b/app/views/bibliographies/fields/_isbn.erb
@@ -3,7 +3,8 @@
         <%= form.simple_fields_for :isbns do |c| %>
             <%= c.input :value, 
                 label: field_label, 
-                as: :string
+                as: :string,
+                hint: hint_text ||= Bibliography::ISBN_HINT
             %>
         <% end %>
     </div>
@@ -19,7 +20,12 @@
                     'association-insertion-node' => '#bibliography_isbn .fields', 
                     'association-insertion-method' => 'append'
                 }, 
-                partial: 'bibliography_standard_identifier_fields' 
+                partial: 'bibliography_standard_identifier_fields',
+                render_options:  {
+                    locals: { 
+                        hint_text: hint_text ||= Bibliography::ISBN_HINT
+                    }
+                }
             %>
         </div>
     </div>


### PR DESCRIPTION
Changed dissertation type to recognize any free text entry with "ph" as a PhD, while all others are defaults to masters (should fix 95% of the current errors in Ph.D. vs phd vs Ph.D ); added ISBN hint and example to avoid issues with dashes